### PR TITLE
peg inspec version 

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -21,3 +21,10 @@
     user_install: no
   with_items: ruby_gems
   when: ruby_gems is iterable
+
+
+- name: Install inspec
+  gem:
+    name: inspec
+    version: 2.3.24
+    state: present


### PR DESCRIPTION
Our emulator and lxc containers need inspec version to be  `2.3.24`